### PR TITLE
Introduced GetConfigurationFiles() method

### DIFF
--- a/src/Abstracts/TestBedFixture.cs
+++ b/src/Abstracts/TestBedFixture.cs
@@ -2,7 +2,9 @@
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;
 using System;
+using System.Collections.Generic;
 using System.IO;
+using System.Linq;
 using System.Threading.Tasks;
 using Xunit.Abstractions;
 using Xunit.Microsoft.DependencyInjection.Logging;
@@ -49,24 +51,32 @@ namespace Xunit.Microsoft.DependencyInjection.Abstracts
 		protected abstract string GetConfigurationFile();
 		protected abstract void AddServices(IServiceCollection services, IConfiguration configuration);
 
+		protected virtual IEnumerable<string> GetConfigurationFiles()
+        {
+			yield return GetConfigurationFile();
+        }
+
 		protected virtual ILoggingBuilder AddLoggingProvider(ILoggingBuilder loggingBuilder, ILoggerProvider loggerProvider)
 			=> loggingBuilder.AddProvider(loggerProvider);
 
 		private IConfigurationRoot GetConfigurationRoot()
 		{
-			var configurationFile = GetConfigurationFile();
-
+			var configurationFiles = GetConfigurationFiles();
 			return
-				!string.IsNullOrEmpty(configurationFile)
-				? GetConfigurationRoot(configurationFile)
+				configurationFiles.All(c => !string.IsNullOrEmpty(c))
+				? GetConfigurationRoot(configurationFiles)
 				: default;
 		}
 
-		private IConfigurationRoot GetConfigurationRoot(string configurationFile) =>
-			new ConfigurationBuilder()
-			.SetBasePath(Directory.GetCurrentDirectory())
-			.AddJsonFile(configurationFile)
-			.Build();
+		private IConfigurationRoot GetConfigurationRoot(IEnumerable<string> configurationFiles)
+		{
+			var builder = new ConfigurationBuilder().SetBasePath(Directory.GetCurrentDirectory());
+			foreach(var configurationFile in configurationFiles)
+            {
+				builder.AddJsonFile(configurationFile);
+            }
+			return builder.Build();
+		}
 
 		protected virtual void Dispose(bool disposing)
 		{


### PR DESCRIPTION
This mentioned method in the title is a virtual one to let developers choose as many `appsettings.xyz.json` files as they wish. This PR closes #75.