### PR TITLE
Making both Clear and DisposeAsyncCore methods virtual

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,7 +48,16 @@ Also, the test class should be decorated by the following attribute:
 [CollectionDefinition("Dependency Injection")]
 ```
 
+#### Clearing managed resources
+
+To have managed resources cleaned up, simply override the virtual method of `Clear()`. This is an optional step.
+
+#### Clearing managed resourced asynchronously
+
+Simply override the virtual method of `DisposeAsyncCore()` for this purpose. This is also an optional step.
+
 ## Running tests in order
+
 The library also has a bonus feature that simplifies running tests in order. The test class does not have to be derived from ```TestBed<T>``` class though and it can apply to all Xunit classes.
 
 Decorate your Xunit test class with the following attribute and associate ```TestOrder(...)``` with ```Fact``` and ```Theory```:

--- a/azure-pipeline-PR.yml
+++ b/azure-pipeline-PR.yml
@@ -17,7 +17,7 @@ steps:
   displayName: 'Use .NET 6.0 sdk'
   inputs:
     packageType: sdk
-    version: 6.0.200
+    version: 6.0.201
     installationPath: $(Agent.ToolsDirectory)/dotnet
 - script: echo Started restoring the source code
 - task: DotNetCoreCLI@2

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -19,7 +19,7 @@ steps:
   displayName: 'Use .NET 6.0 sdk'
   inputs:
     packageType: sdk
-    version: 6.0.200
+    version: 6.0.201
     installationPath: $(Agent.ToolsDirectory)/dotnet
 - script: echo Started restoring the source code
 - task: DotNetCoreCLI@2

--- a/examples/Xunit.Microsoft.DependencyInjection.ExampleTests/IntegrationTests.cs
+++ b/examples/Xunit.Microsoft.DependencyInjection.ExampleTests/IntegrationTests.cs
@@ -1,42 +1,34 @@
 ﻿using Microsoft.Extensions.Options;
 using Options = Xunit.Microsoft.DependencyInjection.ExampleTests.Services.Options;
 
-namespace Xunit.Microsoft.DependencyInjection.ExampleTests
+namespace Xunit.Microsoft.DependencyInjection.ExampleTests;
+
+public class IntegrationTests : TestBed<TestFixture>
 {
-    public class IntegrationTests : TestBed<TestFixture>
+    public IntegrationTests(ITestOutputHelper testOutputHelper, TestFixture fixture)
+        : base(testOutputHelper, fixture)
     {
-        public IntegrationTests(ITestOutputHelper testOutputHelper, TestFixture fixture)
-            : base(testOutputHelper, fixture)
-        {
-        }
+    }
 
-        [Theory]
-        [InlineData(1, 2)]
-        public void Test1(int x, int y)
-        {
-            var calculator = _fixture.GetService<ICalculator>(_testOutputHelper);
-            var option = _fixture.GetService<IOptions<Options>>(_testOutputHelper);
-            var calculated = calculator?.Add(x, y);
-            var expected = option?.Value.Rate * (x + y);
-            Assert.True(expected == calculated);
-        }
+    [Theory]
+    [InlineData(1, 2)]
+    public void Test1(int x, int y)
+    {
+        var calculator = _fixture.GetService<ICalculator>(_testOutputHelper);
+        var option = _fixture.GetService<IOptions<Options>>(_testOutputHelper);
+        var calculated = calculator?.Add(x, y);
+        var expected = option?.Value.Rate * (x + y);
+        Assert.True(expected == calculated);
+    }
 
-        [Theory]
-        [InlineData(1, 2)]
-        public void Test2(int x, int y)
-        {
-            var calculator = _fixture.GetScopedService<ICalculator>(_testOutputHelper);
-            var option = _fixture.GetScopedService<IOptions<Options>>(_testOutputHelper);
-            var calculated = calculator?.Add(x, y);
-            var expected = option?.Value.Rate * (x + y);
-            Assert.True(expected == calculated);
-        }
-
-        protected override void Clear()
-        {
-        }
-
-        protected override ValueTask DisposeAsyncCore()
-            => new();
+    [Theory]
+    [InlineData(1, 2)]
+    public void Test2(int x, int y)
+    {
+        var calculator = _fixture.GetScopedService<ICalculator>(_testOutputHelper);
+        var option = _fixture.GetScopedService<IOptions<Options>>(_testOutputHelper);
+        var calculated = calculator?.Add(x, y);
+        var expected = option?.Value.Rate * (x + y);
+        Assert.True(expected == calculated);
     }
 }

--- a/src/Abstracts/TestBed.cs
+++ b/src/Abstracts/TestBed.cs
@@ -1,6 +1,6 @@
 ﻿namespace Xunit.Microsoft.DependencyInjection.Abstracts;
 
-public abstract class TestBed<TFixture> : IDisposable, IClassFixture<TFixture>, IAsyncDisposable
+public class TestBed<TFixture> : IDisposable, IClassFixture<TFixture>, IAsyncDisposable
 	where TFixture : class
 {
 	protected readonly ITestOutputHelper _testOutputHelper;
@@ -41,8 +41,6 @@ public abstract class TestBed<TFixture> : IDisposable, IClassFixture<TFixture>, 
 		GC.SuppressFinalize(this);
 	}
 
-	protected abstract void Clear();
-
 	public async ValueTask DisposeAsync()
 	{
 		if (!_disposedAsync)
@@ -53,5 +51,6 @@ public abstract class TestBed<TFixture> : IDisposable, IClassFixture<TFixture>, 
 		}
 	}
 
-	protected abstract ValueTask DisposeAsyncCore();
+	protected virtual void Clear() { }
+	protected virtual ValueTask DisposeAsyncCore() => new();
 }


### PR DESCRIPTION
This PR closes #107 after the merge. Summary of changes:

* Making both Clear() and DisposeAsyncCore() virtual methods
* Update the document
* Update the example project
* Update the build pipeline's SDK