### PR TITLE
Defer calling AddServices

### DIFF
--- a/src/Abstracts/TestBedFixture.cs
+++ b/src/Abstracts/TestBedFixture.cs
@@ -12,7 +12,6 @@ public abstract class TestBedFixture : IDisposable, IAsyncDisposable
 		_services = new ServiceCollection();
 		ConfigurationBuilder = new ConfigurationBuilder().SetBasePath(Directory.GetCurrentDirectory());
 		Configuration = GetConfigurationRoot();
-		AddServices(_services, Configuration);
 	}
 
 	public IConfigurationRoot? Configuration { get; private set; }
@@ -25,6 +24,8 @@ public abstract class TestBedFixture : IDisposable, IAsyncDisposable
 			return _serviceProvider;
 		}
 
+		AddServices(_services, Configuration);
+  
 		_services.AddLogging(loggingBuilder => AddLoggingProvider(loggingBuilder, new OutputLoggerProvider(testOutputHelper)));
 		return _serviceProvider = _services.BuildServiceProvider();
 	}

--- a/src/Abstracts/TestBedFixture.cs
+++ b/src/Abstracts/TestBedFixture.cs
@@ -6,12 +6,14 @@ public abstract class TestBedFixture : IDisposable, IAsyncDisposable
 	private IServiceProvider? _serviceProvider;
 	private bool _disposedValue;
 	private bool _disposedAsync;
+	private bool _servicesAdded;
 
 	protected TestBedFixture()
 	{
 		_services = new ServiceCollection();
 		ConfigurationBuilder = new ConfigurationBuilder().SetBasePath(Directory.GetCurrentDirectory());
 		Configuration = GetConfigurationRoot();
+		_servicesAdded = false;
 	}
 
 	public IConfigurationRoot? Configuration { get; private set; }
@@ -23,9 +25,11 @@ public abstract class TestBedFixture : IDisposable, IAsyncDisposable
 		{
 			return _serviceProvider;
 		}
-
-		AddServices(_services, Configuration);
-  
+		if(!_servicesAdded)
+		{
+			AddServices(_services, Configuration);
+			_servicesAdded = true;
+		}
 		_services.AddLogging(loggingBuilder => AddLoggingProvider(loggingBuilder, new OutputLoggerProvider(testOutputHelper)));
 		return _serviceProvider = _services.BuildServiceProvider();
 	}


### PR DESCRIPTION
When placed in the constructor, AddServices is called before the constructor of the deriving fixtures runs. This is suboptimal in cases where the implementation of AddServices depends on something that happens in that constructor.

Examples is loading env variables (dotenv.net package) or bootstrapping a WebApplicationFactory like in ASP.NET integration tests.

In my case, the WebApplicationFactory uses the IMessageSink injected in my fixture constructor by xUnit.