### PR TITLE
Update to xunit 3

### DIFF
--- a/examples/Xunit.Microsoft.DependencyInjection.ExampleTests/GlobalUsings.cs
+++ b/examples/Xunit.Microsoft.DependencyInjection.ExampleTests/GlobalUsings.cs
@@ -2,7 +2,6 @@
 global using Microsoft.Extensions.DependencyInjection;
 global using System.Collections.Generic;
 global using System.Threading.Tasks;
-global using Xunit.Abstractions;
 global using Xunit.Microsoft.DependencyInjection.Abstracts;
 global using Xunit.Microsoft.DependencyInjection.Attributes;
 global using Xunit.Microsoft.DependencyInjection.ExampleTests.Fixtures;

--- a/examples/Xunit.Microsoft.DependencyInjection.ExampleTests/UnitTests.cs
+++ b/examples/Xunit.Microsoft.DependencyInjection.ExampleTests/UnitTests.cs
@@ -1,6 +1,8 @@
+using Xunit.Microsoft.DependencyInjection.TestsOrder;
+
 namespace Xunit.Microsoft.DependencyInjection.ExampleTests;
 
-[TestCaseOrderer("Xunit.Microsoft.DependencyInjection.TestsOrder.TestPriorityOrderer", "Xunit.Microsoft.DependencyInjection")]
+[TestCaseOrderer(typeof(TestPriorityOrderer))]
 public class UnitTests
 {
     [Fact, TestOrder(1)]

--- a/examples/Xunit.Microsoft.DependencyInjection.ExampleTests/Xunit.Microsoft.DependencyInjection.ExampleTests.csproj
+++ b/examples/Xunit.Microsoft.DependencyInjection.ExampleTests/Xunit.Microsoft.DependencyInjection.ExampleTests.csproj
@@ -7,13 +7,14 @@
 		<Nullable>enable</Nullable>
 		<ImplicitUsings>enable</ImplicitUsings>
 		<UserSecretsId>59bdc82c-5628-47c8-a5ec-3630c3a2bc45</UserSecretsId>
+		<OutputType>Exe</OutputType>
 	</PropertyGroup>
 
 	<ItemGroup>
 		<PackageReference Include="Microsoft.Extensions.Configuration.UserSecrets" Version="9.0.5" />
 		<PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.13.0" />
-		<PackageReference Include="xunit" Version="2.9.3" />
-		<PackageReference Include="xunit.runner.visualstudio" Version="3.1.0">
+		<PackageReference Include="xunit.v3" Version="2.0.3" />
+		<PackageReference Include="xunit.runner.visualstudio" Version="3.1.1">
 		  <PrivateAssets>all</PrivateAssets>
 		  <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
 		</PackageReference>

--- a/src/GlobalUsings.cs
+++ b/src/GlobalUsings.cs
@@ -1,7 +1,6 @@
 ﻿global using Microsoft.Extensions.Configuration;
 global using Microsoft.Extensions.DependencyInjection;
 global using Microsoft.Extensions.Logging;
-global using Xunit.Abstractions;
 global using Xunit.Microsoft.DependencyInjection.Attributes;
 global using Xunit.Microsoft.DependencyInjection.Logging;
 global using Xunit.Sdk;

--- a/src/Xunit.Microsoft.DependencyInjection.csproj
+++ b/src/Xunit.Microsoft.DependencyInjection.csproj
@@ -9,10 +9,9 @@
   <ItemGroup>
     <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="9.0.5" />
     <PackageReference Include="Microsoft.Extensions.Logging" Version="9.0.5" />
-    <PackageReference Include="xunit.abstractions" Version="2.0.3" />
     <PackageReference Include="Microsoft.Extensions.Configuration.FileExtensions" Version="9.0.5" />
     <PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="9.0.5" />
-    <PackageReference Include="xunit.core" Version="2.9.3" />
+    <PackageReference Include="xunit.v3.extensibility.core" Version="2.0.3" />
     <PackageReference Include="Microsoft.Extensions.Configuration.EnvironmentVariables" Version="9.0.5" />
   </ItemGroup>
   <ItemGroup>


### PR DESCRIPTION
Updated packages to new major version of xunit. Unit tests succeed but I dont know if the changes, especially in TestPriorityOrderer are sufficient. There are null reference warnings because properties of ITestCase are nullable.

I also have no idea what strategy would be best in terms of versioning. Xunit chose to publish completely new packages...
