### PR TITLE
docs: fix async scope method signature

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,7 +63,7 @@ public T GetService<T>(ITestOutputHelper testOutputHelper);
 To access async scopes simply call the following method in the abstract fixture class:
 
 ```csharp
-public AsyncServiceScope GetAsyncScope<T>(ITestOutputHelper testOutputHelper)
+public AsyncServiceScope GetAsyncScope(ITestOutputHelper testOutputHelper);
 ```
 
 ### Accessing the keyed wired up services in .NET 9.0


### PR DESCRIPTION
## Summary
- document `GetAsyncScope` without generic type parameter in README

## Testing
- `dotnet build` *(fails: command not found)*
- `apt-get update` *(fails: repository 403)*

------
https://chatgpt.com/codex/tasks/task_e_689d3fc9a3e083338876f193aebfd58e