### PR TITLE
Use Assert.Equal in calculator example tests

### DIFF
--- a/examples/Xunit.Microsoft.DependencyInjection.ExampleTests/CalculatorTests.cs
+++ b/examples/Xunit.Microsoft.DependencyInjection.ExampleTests/CalculatorTests.cs
@@ -17,7 +17,7 @@ public class CalculatorTests : TestBed<TestProjectFixture>
         var calculator = _fixture.GetService<ICalculator>(_testOutputHelper)!;
         var calculatedValue = await calculator.AddAsync(x, y);
         var expected = _options.Rate * (x + y);
-        Assert.True(expected == calculatedValue);
+        Assert.Equal(expected, calculatedValue);
     }
 
     [Theory]
@@ -27,6 +27,6 @@ public class CalculatorTests : TestBed<TestProjectFixture>
         var calculator = _fixture.GetScopedService<ICalculator>(_testOutputHelper)!;
         var calculatedValue = await calculator.AddAsync(x, y);
         var expected = _options.Rate * (x + y);
-        Assert.True(expected == calculatedValue);
+        Assert.Equal(expected, calculatedValue);
     }
 }


### PR DESCRIPTION
## Summary
- replace Assert.True comparisons with Assert.Equal

## Testing
- `dotnet test examples/Xunit.Microsoft.DependencyInjection.ExampleTests` *(fails: dotnet command not found)*


------
https://chatgpt.com/codex/tasks/task_e_689d407259648333af521a9ecc408ff6