### PR TITLE
Update xUnit package versions to latest patch #308

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -1,7 +1,7 @@
 variables:
   Major: 9
   Minor: 1
-  Revision: 1
+  Revision: 2
   BuildConfiguration: Release
 
 name: $(Major).$(Minor).$(Revision)

--- a/examples/Xunit.Microsoft.DependencyInjection.ExampleTests/Xunit.Microsoft.DependencyInjection.ExampleTests.csproj
+++ b/examples/Xunit.Microsoft.DependencyInjection.ExampleTests/Xunit.Microsoft.DependencyInjection.ExampleTests.csproj
@@ -13,8 +13,8 @@
 	<ItemGroup>
 		<PackageReference Include="Microsoft.Extensions.Configuration.UserSecrets" Version="9.0.8" />
 		<PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.14.1" />
-		<PackageReference Include="xunit.v3" Version="3.0.0" />
-		<PackageReference Include="xunit.runner.visualstudio" Version="3.1.3">
+		<PackageReference Include="xunit.v3" Version="3.0.1" />
+		<PackageReference Include="xunit.runner.visualstudio" Version="3.1.4">
 		  <PrivateAssets>all</PrivateAssets>
 		  <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
 		</PackageReference>

--- a/src/Xunit.Microsoft.DependencyInjection.csproj
+++ b/src/Xunit.Microsoft.DependencyInjection.csproj
@@ -11,7 +11,7 @@
     <PackageReference Include="Microsoft.Extensions.Logging" Version="9.0.8" />
     <PackageReference Include="Microsoft.Extensions.Configuration.FileExtensions" Version="9.0.8" />
     <PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="9.0.8" />
-    <PackageReference Include="xunit.v3.extensibility.core" Version="3.0.0" />
+    <PackageReference Include="xunit.v3.extensibility.core" Version="3.0.1" />
     <PackageReference Include="Microsoft.Extensions.Configuration.EnvironmentVariables" Version="9.0.8" />
   </ItemGroup>
   <ItemGroup>


### PR DESCRIPTION
Bumped xunit.v3 and xunit.runner.visualstudio in the example tests project, and xunit.v3.extensibility.core in the main project, to their latest patch versions for improved stability and compatibility.