### PR TITLE
Bump version to 10.0.1 and update dependencies #335

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -5,19 +5,19 @@
   </PropertyGroup>
   <ItemGroup>
     <!-- Microsoft.Extensions packages (core dependencies) -->
-    <PackageVersion Include="Microsoft.Extensions.DependencyInjection" Version="10.0.0" />
-    <PackageVersion Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="10.0.0" />
-    <PackageVersion Include="Microsoft.Extensions.Configuration" Version="10.0.0" />
-    <PackageVersion Include="Microsoft.Extensions.Options" Version="10.0.0" />
-    <PackageVersion Include="Microsoft.Extensions.Configuration.Binder" Version="10.0.0" />
-    <PackageVersion Include="Microsoft.Extensions.Configuration.FileExtensions" Version="10.0.0" />
-    <PackageVersion Include="Microsoft.Extensions.Configuration.Json" Version="10.0.0" />
-    <PackageVersion Include="Microsoft.Extensions.Logging" Version="10.0.0" />
-    <PackageVersion Include="Microsoft.Extensions.Configuration.EnvironmentVariables" Version="10.0.0" />
-    <PackageVersion Include="Microsoft.Extensions.Configuration.UserSecrets" Version="10.0.0" />
+    <PackageVersion Include="Microsoft.Extensions.DependencyInjection" Version="10.0.1" />
+    <PackageVersion Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="10.0.1" />
+    <PackageVersion Include="Microsoft.Extensions.Configuration" Version="10.0.1" />
+    <PackageVersion Include="Microsoft.Extensions.Options" Version="10.0.1" />
+    <PackageVersion Include="Microsoft.Extensions.Configuration.Binder" Version="10.0.1" />
+    <PackageVersion Include="Microsoft.Extensions.Configuration.FileExtensions" Version="10.0.1" />
+    <PackageVersion Include="Microsoft.Extensions.Configuration.Json" Version="10.0.1" />
+    <PackageVersion Include="Microsoft.Extensions.Logging" Version="10.0.1" />
+    <PackageVersion Include="Microsoft.Extensions.Configuration.EnvironmentVariables" Version="10.0.1" />
+    <PackageVersion Include="Microsoft.Extensions.Configuration.UserSecrets" Version="10.0.1" />
     <!-- xUnit packages -->
-    <PackageVersion Include="xunit.v3.extensibility.core" Version="3.2.0" />
-    <PackageVersion Include="xunit.v3" Version="3.2.0" />
+    <PackageVersion Include="xunit.v3.extensibility.core" Version="3.2.1" />
+    <PackageVersion Include="xunit.v3" Version="3.2.1" />
     <PackageVersion Include="xunit.runner.visualstudio" Version="3.1.5" />
     <!-- Development and build tools -->
     <PackageVersion Include="Microsoft.SourceLink.GitHub" Version="8.0.0" />

--- a/azure-pipeline-PR.yml
+++ b/azure-pipeline-PR.yml
@@ -1,7 +1,7 @@
 variables:
   Major: 10
   Minor: 0
-  Patch: 0
+  Patch: 1
   BuildConfiguration: Release
 
 name: $(Major).$(Minor).$(Patch).$(rev:r)

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -1,7 +1,7 @@
 variables:
   Major: 10
   Minor: 0
-  Revision: 0
+  Revision: 1
   BuildConfiguration: Release
 
 name: $(Major).$(Minor).$(Revision)

--- a/src/Xunit.Microsoft.DependencyInjection.csproj
+++ b/src/Xunit.Microsoft.DependencyInjection.csproj
@@ -6,7 +6,7 @@
     <ImplicitUsings>enable</ImplicitUsings>
     
     <!-- Version configuration - can be overridden by build system -->
-    <Version Condition="'$(Version)' == ''">10.0.0</Version>
+    <Version Condition="'$(Version)' == ''">10.0.1</Version>
 	
     <!-- NuGet Package Properties -->
     <PackageId>Xunit.Microsoft.DependencyInjection</PackageId>


### PR DESCRIPTION
Updated Microsoft.Extensions and xUnit package versions to latest patch releases (10.0.1 and 3.2.1 respectively). Incremented version numbers in build pipeline files and project file to 10.0.1 for consistency with dependency updates. Closes #335