### PR TITLE
Dispose service provider asynchronously

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,6 +18,7 @@ This library brings **Microsoft's dependency injection container** to Xunit by l
 - 🔑 **Keyed services support** - Full .NET 10.0 keyed services integration
 - ⚙️ **Configuration integration** - Support for `appsettings.json`, user secrets, and environment variables
 - 🧪 **Service lifetime management** - Transient, Scoped, and Singleton services work as expected
+- ♻️ **Async disposal support** - Container-managed `IAsyncDisposable` services are disposed asynchronously during fixture teardown
 - 📦 **Microsoft.Extensions ecosystem** - Built on the same DI container used by ASP.NET Core
 - 🔄 **Gradual migration** - Adopt new features incrementally without breaking existing tests
 - 🏗️ **Production-ready** - Used by [Digital Silo](https://digitalsilo.io/) and other production applications
@@ -141,13 +142,15 @@ public class MyTraditionalTests : TestBed<MyTestFixture>
 
 ### Setup your fixture
 
-The abstract class of `Xunit.Microsoft.DependencyInjection.Abstracts.TestBedFixture` contains the necessary functionalities to add services and configurations to Microsoft's dependency injection container. Your concrete test fixture class must derive from this abstract class and implement the following two abstract methods:
+The abstract class of `Xunit.Microsoft.DependencyInjection.Abstracts.TestBedFixture` contains the necessary functionalities to add services and configurations to Microsoft's dependency injection container. Your concrete test fixture class must derive from this abstract class and implement the following abstract methods:
 
 ```csharp
 protected abstract void AddServices(IServiceCollection services, IConfiguration? configuration);
 protected abstract IEnumerable<TestAppSettings> GetTestAppSettings();
 protected abstract ValueTask DisposeAsyncCore();
 ```
+
+Use `DisposeAsyncCore()` to clean up fixture-owned resources (for example, files, sockets, or external clients created by the fixture). Service cleanup for dependencies resolved from the DI container is handled by the framework during async teardown.
 
 `TestBedFixture` now ignores any `TestAppSettings` entries whose `Filename` is null or empty before calling `AddJsonFile`. That means you can safely return placeholder descriptors or rely only on environment variables; optional JSON files can simply leave `Filename` blank and the framework skips them automatically when building the configuration root.
  
@@ -290,9 +293,24 @@ Also, the test class should be decorated by the following attribute:
 
 To have managed resources cleaned up, simply override the virtual method of `Clear()`. This is an optional step.
 
-#### Clearing managed resourced asynchronously
+#### Clearing managed resources asynchronously
 
-Simply override the virtual method of `DisposeAsyncCore()` for this purpose. This is also an optional step.
+`TestBedFixture` performs async teardown and disposes the DI `ServiceProvider` asynchronously. This ensures container-managed services implementing `IAsyncDisposable` are disposed correctly during fixture teardown.
+
+If you need additional async cleanup for fixture-owned resources, override `DisposeAsyncCore()`:
+
+```csharp
+public sealed class MyTestFixture : TestBedFixture
+{
+    protected override ValueTask DisposeAsyncCore()
+    {
+        // Cleanup resources created/owned by the fixture itself.
+        return ValueTask.CompletedTask;
+    }
+}
+```
+
+For a full working example, see `AsyncDisposableTests` and `AsyncDisposableFixture` in the examples project.
 
 ## Running tests in order
 
@@ -322,6 +340,7 @@ public IConfigurationBuilder ConfigurationBuilder { get; private set; }
 * **Factory pattern**: See `FactoryConstructorInjectionTests.cs` for experimental constructor injection scenarios
 * **Keyed services**: See `KeyedServicesTests.cs` for .NET 9.0 keyed service examples
 * **Configuration**: See `UserSecretTests.cs` for configuration and user secrets integration
+* **Async disposal**: See `AsyncDisposableTests.cs` and `Fixtures/AsyncDisposableFixture.cs` for async teardown of `IAsyncDisposable` services
 * **Advanced patterns**: See `AdvancedDependencyInjectionTests.cs` for `IOptions<T>`, `Func<T>`, and `Action<T>` examples
 
 🏢 [Digital Silo](https://digitalsilo.io/)'s unit tests and integration tests are using this library in production.

--- a/azure-pipeline-PR.yml
+++ b/azure-pipeline-PR.yml
@@ -1,7 +1,7 @@
 variables:
   Major: 10
   Minor: 0
-  Patch: 3
+  Patch: 4
   BuildConfiguration: Release
 
 name: $(Major).$(Minor).$(Patch).$(rev:r)

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -1,13 +1,13 @@
 variables:
   Major: 10
   Minor: 0
-  Revision: 3
+  Revision: 4
   BuildConfiguration: Release
 
 name: $(Major).$(Minor).$(Revision)
 pr: none
 trigger:
-  batch: true
+  batch: 'true'
   tags:
    include:
      - refs/tags/*

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -7,7 +7,7 @@ variables:
 name: $(Major).$(Minor).$(Revision)
 pr: none
 trigger:
-  batch: 'true'
+  batch: true
   tags:
    include:
      - refs/tags/*

--- a/examples/Xunit.Microsoft.DependencyInjection.ExampleTests/AsyncDisposableTests.cs
+++ b/examples/Xunit.Microsoft.DependencyInjection.ExampleTests/AsyncDisposableTests.cs
@@ -1,0 +1,16 @@
+namespace Xunit.Microsoft.DependencyInjection.ExampleTests;
+
+public class AsyncDisposableTests : TestBed<AsyncDisposableFixture>
+{
+    public AsyncDisposableTests(ITestOutputHelper testOutputHelper, AsyncDisposableFixture fixture) 
+        : base(testOutputHelper, fixture)
+    {
+    }
+    
+    [Fact]
+    public void EnvironmentVariablesViaConstructorAreAvailable()
+    {
+        var service = _fixture.GetService<AsyncDisposableService>(_testOutputHelper);
+        Assert.NotNull(service);
+    }
+}

--- a/examples/Xunit.Microsoft.DependencyInjection.ExampleTests/AsyncDisposableTests.cs
+++ b/examples/Xunit.Microsoft.DependencyInjection.ExampleTests/AsyncDisposableTests.cs
@@ -6,9 +6,11 @@ public class AsyncDisposableTests : TestBed<AsyncDisposableFixture>
         : base(testOutputHelper, fixture)
     {
     }
-    
+
+    // The test itself will pass but `dotnet  test` will fail in the teardown
+    // when the AsyncDisposableService has not been disposed asynchronously.
     [Fact]
-    public void EnvironmentVariablesViaConstructorAreAvailable()
+    public void AsyncDisposableServiceGetsDisposedAsynchronously()
     {
         var service = _fixture.GetService<AsyncDisposableService>(_testOutputHelper);
         Assert.NotNull(service);

--- a/examples/Xunit.Microsoft.DependencyInjection.ExampleTests/AsyncDisposableTests.cs
+++ b/examples/Xunit.Microsoft.DependencyInjection.ExampleTests/AsyncDisposableTests.cs
@@ -7,7 +7,7 @@ public class AsyncDisposableTests : TestBed<AsyncDisposableFixture>
     {
     }
 
-    // The test itself will pass but `dotnet  test` will fail in the teardown
+    // The test itself will pass but `dotnet test` will fail in the teardown
     // when the AsyncDisposableService has not been disposed asynchronously.
     [Fact]
     public void AsyncDisposableServiceGetsDisposedAsynchronously()

--- a/examples/Xunit.Microsoft.DependencyInjection.ExampleTests/Fixtures/AsyncDisposableFixture.cs
+++ b/examples/Xunit.Microsoft.DependencyInjection.ExampleTests/Fixtures/AsyncDisposableFixture.cs
@@ -1,0 +1,17 @@
+﻿namespace Xunit.Microsoft.DependencyInjection.ExampleTests.Fixtures;
+
+public class AsyncDisposableFixture : TestBedFixture
+{
+  protected override void AddServices(
+    IServiceCollection services,
+    IConfiguration configuration
+  )
+  {
+    services.AddSingleton<AsyncDisposableService>();
+  }
+
+  protected override ValueTask DisposeAsyncCore()
+  {
+    return ValueTask.CompletedTask;
+  }
+}

--- a/examples/Xunit.Microsoft.DependencyInjection.ExampleTests/Services/AsyncDisposableService.cs
+++ b/examples/Xunit.Microsoft.DependencyInjection.ExampleTests/Services/AsyncDisposableService.cs
@@ -1,0 +1,24 @@
+namespace Xunit.Microsoft.DependencyInjection.ExampleTests.Services;
+
+/// <summary>
+/// A service that needs asynchronous disposal logic.
+/// </summary>
+public class AsyncDisposableService : IDisposable, IAsyncDisposable
+{
+  private bool _disposedAsync;
+
+  public ValueTask DisposeAsync()
+  {
+    _disposedAsync = true;
+
+    return ValueTask.CompletedTask;
+  }
+
+  public void Dispose()
+  {
+    if (!_disposedAsync)
+    {
+      throw new Exception("The AsyncDisposable service has NOT been disposed asynchronously.");
+    }
+  }
+}

--- a/examples/Xunit.Microsoft.DependencyInjection.ExampleTests/Services/AsyncDisposableService.cs
+++ b/examples/Xunit.Microsoft.DependencyInjection.ExampleTests/Services/AsyncDisposableService.cs
@@ -10,6 +10,7 @@ public class AsyncDisposableService : IDisposable, IAsyncDisposable
   public ValueTask DisposeAsync()
   {
     _disposedAsync = true;
+    GC.SuppressFinalize(this);
 
     return ValueTask.CompletedTask;
   }

--- a/src/Abstracts/TestBedFixture.cs
+++ b/src/Abstracts/TestBedFixture.cs
@@ -114,6 +114,10 @@ public abstract class TestBedFixture : IDisposable, IAsyncDisposable
 		if (!_disposedAsync)
 		{
 			await DisposeAsyncCore();
+			if (_serviceProvider is not null)
+			{
+				await ((ServiceProvider)_serviceProvider).DisposeAsync();
+			}
 			Dispose();
 			_disposedAsync = true;
 		}

--- a/src/Abstracts/TestBedFixture.cs
+++ b/src/Abstracts/TestBedFixture.cs
@@ -116,7 +116,7 @@ public abstract class TestBedFixture : IDisposable, IAsyncDisposable
 			await DisposeAsyncCore();
 			if (_serviceProvider is not null)
 			{
-				await ((ServiceProvider)_serviceProvider).DisposeAsync();
+				await _serviceProvider.DisposeAsync();
 				_serviceProvider = null;
 			}
 			Dispose();

--- a/src/Abstracts/TestBedFixture.cs
+++ b/src/Abstracts/TestBedFixture.cs
@@ -117,6 +117,7 @@ public abstract class TestBedFixture : IDisposable, IAsyncDisposable
 			if (_serviceProvider is not null)
 			{
 				await ((ServiceProvider)_serviceProvider).DisposeAsync();
+				_serviceProvider = null;
 			}
 			Dispose();
 			_disposedAsync = true;

--- a/src/Xunit.Microsoft.DependencyInjection.csproj
+++ b/src/Xunit.Microsoft.DependencyInjection.csproj
@@ -6,7 +6,7 @@
     <ImplicitUsings>enable</ImplicitUsings>
     
     <!-- Version configuration - can be overridden by build system -->
-    <Version Condition="'$(Version)' == ''">10.0.3</Version>
+    <Version Condition="'$(Version)' == ''">10.0.4</Version>
 	
     <!-- NuGet Package Properties -->
     <PackageId>Xunit.Microsoft.DependencyInjection</PackageId>
@@ -15,7 +15,7 @@
     <Company>Umplify Technologies Inc.</Company>
     <Product>Xunit.Microsoft.DependencyInjection</Product>
     <Description>This package contains the necessary classes and features to leverage Xunit's fixture class for Microsoft dependency injection framework.</Description>
-    <Copyright>2025 - All rights reserved, Umplify Technologies Inc.</Copyright>
+    <Copyright>2026 - All rights reserved, Umplify Technologies Inc.</Copyright>
     <PackageTags>xunit;dependency-injection;microsoft-dependency-injection;xunit-dependency-injection</PackageTags>
     <PackageProjectUrl>https://umplify.github.io/xunit-dependency-injection/</PackageProjectUrl>
     <PackageLicenseExpression>MIT</PackageLicenseExpression>


### PR DESCRIPTION
@Arash-Sabet I am playing with the [MassTransit](https://masstransit.io/) library. They have a [Test Harness](https://masstransit.io/documentation/concepts/testing) which is added to the services and needs async disposal. Since the `TestBedFixture` does not yet call `DisposeAsync` on the service provider, an exception is thrown by the test harness making the tests fail.

I added a call to asynchronously dispose the service provider (and thus all async disposable services) together with a unit test. All tests are green.