### PR TITLE
Upgrade NuGet packages to latest stable releases, bump library to 10.…

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -5,23 +5,23 @@
   </PropertyGroup>
   <ItemGroup>
     <!-- Microsoft.Extensions packages (core dependencies) -->
-    <PackageVersion Include="Microsoft.Extensions.DependencyInjection" Version="10.0.3" />
-    <PackageVersion Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="10.0.3" />
-    <PackageVersion Include="Microsoft.Extensions.Configuration" Version="10.0.3" />
-    <PackageVersion Include="Microsoft.Extensions.Options" Version="10.0.3" />
-    <PackageVersion Include="Microsoft.Extensions.Configuration.Binder" Version="10.0.3" />
-    <PackageVersion Include="Microsoft.Extensions.Configuration.FileExtensions" Version="10.0.3" />
-    <PackageVersion Include="Microsoft.Extensions.Configuration.Json" Version="10.0.3" />
-    <PackageVersion Include="Microsoft.Extensions.Logging" Version="10.0.3" />
-    <PackageVersion Include="Microsoft.Extensions.Configuration.EnvironmentVariables" Version="10.0.3" />
-    <PackageVersion Include="Microsoft.Extensions.Configuration.UserSecrets" Version="10.0.3" />
+    <PackageVersion Include="Microsoft.Extensions.DependencyInjection" Version="10.0.9" />
+    <PackageVersion Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="10.0.9" />
+    <PackageVersion Include="Microsoft.Extensions.Configuration" Version="10.0.9" />
+    <PackageVersion Include="Microsoft.Extensions.Options" Version="10.0.9" />
+    <PackageVersion Include="Microsoft.Extensions.Configuration.Binder" Version="10.0.9" />
+    <PackageVersion Include="Microsoft.Extensions.Configuration.FileExtensions" Version="10.0.9" />
+    <PackageVersion Include="Microsoft.Extensions.Configuration.Json" Version="10.0.9" />
+    <PackageVersion Include="Microsoft.Extensions.Logging" Version="10.0.9" />
+    <PackageVersion Include="Microsoft.Extensions.Configuration.EnvironmentVariables" Version="10.0.9" />
+    <PackageVersion Include="Microsoft.Extensions.Configuration.UserSecrets" Version="10.0.9" />
     <!-- xUnit packages -->
     <PackageVersion Include="xunit.v3.extensibility.core" Version="3.2.2" />
     <PackageVersion Include="xunit.v3" Version="3.2.2" />
     <PackageVersion Include="xunit.runner.visualstudio" Version="3.1.5" />
     <!-- Development and build tools -->
-    <PackageVersion Include="Microsoft.SourceLink.GitHub" Version="10.0.103" />
-    <PackageVersion Include="Microsoft.NET.Test.Sdk" Version="18.0.1" />
-    <PackageVersion Include="coverlet.collector" Version="8.0.0" />
+    <PackageVersion Include="Microsoft.SourceLink.GitHub" Version="10.0.300" />
+    <PackageVersion Include="Microsoft.NET.Test.Sdk" Version="18.7.0" />
+    <PackageVersion Include="coverlet.collector" Version="10.0.1" />
   </ItemGroup>
 </Project>

--- a/azure-pipeline-PR.yml
+++ b/azure-pipeline-PR.yml
@@ -1,7 +1,7 @@
 variables:
   Major: 10
   Minor: 0
-  Patch: 4
+  Patch: 5
   BuildConfiguration: Release
 
 name: $(Major).$(Minor).$(Patch).$(rev:r)
@@ -17,7 +17,7 @@ steps:
   displayName: 'Use .NET 10.0 sdk'
   inputs:
     packageType: sdk
-    version: 10.0.103
+    version: 10.0.301
     installationPath: $(Agent.ToolsDirectory)/dotnet
 - script: echo Started restoring the source code
 - task: DotNetCoreCLI@2

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -1,7 +1,7 @@
 variables:
   Major: 10
   Minor: 0
-  Revision: 4
+  Revision: 5
   BuildConfiguration: Release
 
 name: $(Major).$(Minor).$(Revision)
@@ -25,7 +25,7 @@ steps:
   displayName: 'Use .NET 10.0 sdk'
   inputs:
     packageType: sdk
-    version: 10.0.103
+    version: 10.0.301
     installationPath: $(Agent.ToolsDirectory)/dotnet
 - script: echo Started restoring the source code
 - task: DotNetCoreCLI@2

--- a/src/Xunit.Microsoft.DependencyInjection.csproj
+++ b/src/Xunit.Microsoft.DependencyInjection.csproj
@@ -6,7 +6,7 @@
     <ImplicitUsings>enable</ImplicitUsings>
     
     <!-- Version configuration - can be overridden by build system -->
-    <Version Condition="'$(Version)' == ''">10.0.4</Version>
+    <Version Condition="'$(Version)' == ''">10.0.5</Version>
 	
     <!-- NuGet Package Properties -->
     <PackageId>Xunit.Microsoft.DependencyInjection</PackageId>


### PR DESCRIPTION
…0.5, .NET SDK to 10.0.301

Package version bumps:
- Microsoft.Extensions.* 10.0.3 -> 10.0.9
- Microsoft.SourceLink.GitHub 10.0.103 -> 10.0.300
- Microsoft.NET.Test.Sdk 18.0.1 -> 18.7.0
- coverlet.collector 8.0.0 -> 10.0.1

Other changes:
- Library version 10.0.4 -> 10.0.5
- .NET SDK 10.0.103 -> 10.0.301 in azure-pipelines.yml and azure-pipeline-PR.yml
- Pipeline revision/patch 4 -> 5

xunit.v3, xunit.v3.extensibility.core, and xunit.runner.visualstudio left unchanged (already at latest stable).